### PR TITLE
Add support for Wi-Fi settings and password

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1770,6 +1770,16 @@
         <param index="7">Reserved (set to 0)</param>
       </entry>
       <!-- END of UAVCAN range -->
+      <entry value="6000" name="MAV_CMD_GET_WIFI_NETWORKS_INFO">
+        <description>Commands the vehicle to respond with a sequence of messages WIFI_NETWORK_INFO. The losses can be detected with MAV_CMD_REQUEST_WIFI_NETWORKS_COUNT</description>
+        <param index="1">0: No Action 1: Request messages with saved Wi-Fi networks 2: Request messages with scanned Wi-Fi network info</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
+      <entry value="6003" name="MAV_CMD_GET_WIFI_NETWORKS_COUNT">
+        <description>Requests number of saved/scanned Wi-Fi networks (See WIFI_NETWORKS_COUNT).</description>
+        <param index="1">0: No Action 1: Requests number of saved Wi-Fi networks 2: Requests number of scanned Wi-Fi networks</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
       <!-- VALUES FROM 0-40000 are reserved for the common message set. Values from 40000 to UINT16_MAX are available for dialects -->
       <!-- BEGIN of payload range (30000 to 30999) -->
       <entry value="30001" name="MAV_CMD_PAYLOAD_PREPARE_DEPLOY">
@@ -4615,6 +4625,17 @@
       <field type="uint32_t" name="bitrate" units="bits/s">Bit rate in bits per second (set to -1 for auto)</field>
       <field type="uint16_t" name="rotation" units="deg">Video image rotation clockwise (0-359 degrees)</field>
       <field type="char[230]" name="uri">Video stream URI</field>
+    </message>
+    <message id="293" name="WIFI_NETWORK_INFO">
+      <description>Information about network (see MAV_CMD_GET_WIFI_NETWORKS_INFO)</description>
+      <field type="char[32]" name="ssid">Name of network (SSID)</field>
+      <field type="uint8_t" name="security_type" enum="WIFI_SECURITY_TYPE">Security type (See WIFI_SECURITY_TYPE).</field>
+      <field type="uint8_t" name="type">Type of network (0: saved 1: scanned)</field>
+    </message>
+    <message id="298" name="WIFI_NETWORKS_COUNT">
+      <description>Number of saved/scanned Wi-Fi networks (See MAV_CMD_GET_WIFI_NETWORKS_COUNT)</description>
+      <field type="uint8_t" name="type">Type of networks (0: saved 1: scanned)</field>
+      <field type="uint8_t" name="count">Number of networks</field>
     </message>
     <message id="299" name="WIFI_CONFIG_AP">
       <description>Configure AP SSID and Password.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -2932,6 +2932,21 @@
         <param index="5">Yaw [rad], set to NaN for unchanged</param>
       </entry>
     </enum>
+    <enum name="WIFI_SECURITY_TYPE">
+      <description>Type of Wi-Fi security</description>
+      <entry value="0" name="WIFI_SECURITY_TYPE_OPEN">
+        <description>No security</description>
+      </entry>
+      <entry value="1" name="WIFI_SECURITY_TYPE_WEP">
+        <description>WEP (Wired Equivalent Privacy) security</description>
+      </entry>
+      <entry value="2" name="WIFI_SECURITY_TYPE_WPA">
+        <description>WPA (Wi-Fi Protected Access) security</description>
+      </entry>
+      <entry value="3" name="WIFI_SECURITY_TYPE_WPA2">
+        <description>WPA2 (Wi-Fi Protected Access II) security</description>
+      </entry>
+    </enum>
   </enums>
   <messages>
     <message id="0" name="HEARTBEAT">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -485,6 +485,9 @@
       <entry value="241" name="MAV_COMP_ID_UART_BRIDGE">
         <description/>
       </entry>
+      <entry value="242" name="MAV_COMP_ID_WIFI">
+        <description/>
+      </entry>
       <entry value="250" name="MAV_COMP_ID_SYSTEM_CONTROL">
         <description/>
       </entry>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1775,6 +1775,11 @@
         <param index="1">0: No Action 1: Request messages with saved Wi-Fi networks 2: Request messages with scanned Wi-Fi network info</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
+      <entry value="6002" name="MAV_CMD_GET_WIFI_STATUS">
+        <description>Requests current Wi-Fi status (See WIFI_STATUS).</description>
+        <param index="1">0: No Action 1: Request Wi-Fi state</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
       <entry value="6003" name="MAV_CMD_GET_WIFI_NETWORKS_COUNT">
         <description>Requests number of saved/scanned Wi-Fi networks (See WIFI_NETWORKS_COUNT).</description>
         <param index="1">0: No Action 1: Requests number of saved Wi-Fi networks 2: Requests number of scanned Wi-Fi networks</param>
@@ -2955,6 +2960,18 @@
       </entry>
       <entry value="3" name="WIFI_SECURITY_TYPE_WPA2">
         <description>WPA2 (Wi-Fi Protected Access II) security</description>
+      </entry>
+    </enum>
+    <enum name="WIFI_STATE">
+      <description>State of Wi-Fi</description>
+      <entry value="0" name="WIFI_STATE_UNDEFINED">
+        <description>Undefined state</description>
+      </entry>
+      <entry value="1" name="WIFI_STATE_AP">
+        <description>Wi-Fi works in AP(Access point) mode</description>
+      </entry>
+      <entry value="2" name="WIFI_STATE_CLIENT">
+        <description>Wi-Fi works in client mode (Connected to another access point)</description>
       </entry>
     </enum>
   </enums>
@@ -4631,6 +4648,11 @@
       <field type="char[32]" name="ssid">Name of network (SSID)</field>
       <field type="uint8_t" name="security_type" enum="WIFI_SECURITY_TYPE">Security type (See WIFI_SECURITY_TYPE).</field>
       <field type="uint8_t" name="type">Type of network (0: saved 1: scanned)</field>
+    </message>
+    <message id="294" name="WIFI_STATUS">
+      <description>Status of Wi-Fi (see MAV_CMD_GET_WIFI_STATUS)</description>
+      <field type="uint8_t" name="state" enum="WIFI_STATE">Current state of Wi-Fi (See WIFI_STATE)</field>
+      <field type="char[32]" name="ssid">Name of network (SSID) if device works in client mode, otherwise undefined</field>
     </message>
     <message id="298" name="WIFI_NETWORKS_COUNT">
       <description>Number of saved/scanned Wi-Fi networks (See MAV_CMD_GET_WIFI_NETWORKS_COUNT)</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1775,6 +1775,11 @@
         <param index="1">0: No Action 1: Request messages with saved Wi-Fi networks 2: Request messages with scanned Wi-Fi network info</param>
         <param index="2">Reserved (all remaining params)</param>
       </entry>
+      <entry value="6001" name="MAV_CMD_WIFI_START_AP">
+        <description>Start in AP (Access Point) mode.</description>
+        <param index="1">0: No Action 1: Perform start in AP</param>
+        <param index="2">Reserved (all remaining params)</param>
+      </entry>
       <entry value="6002" name="MAV_CMD_GET_WIFI_STATUS">
         <description>Requests current Wi-Fi status (See WIFI_STATUS).</description>
         <param index="1">0: No Action 1: Request Wi-Fi state</param>
@@ -4653,6 +4658,20 @@
       <description>Status of Wi-Fi (see MAV_CMD_GET_WIFI_STATUS)</description>
       <field type="uint8_t" name="state" enum="WIFI_STATE">Current state of Wi-Fi (See WIFI_STATE)</field>
       <field type="char[32]" name="ssid">Name of network (SSID) if device works in client mode, otherwise undefined</field>
+    </message>
+    <message id="295" name="WIFI_NETWORK_CONNECT">
+      <description>Connect to Wi-Fi network</description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network</field>
+    </message>
+    <message id="296" name="WIFI_NETWORK_ADD">
+      <description>Save Wi-Fi network on device</description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network (SSID)</field>
+      <field type="char[64]" name="password">Password</field>
+      <field type="uint8_t" name="security_type" enum="WIFI_SECURITY_TYPE">Security type (See WIFI_SECURITY_TYPE).</field>
+    </message>
+    <message id="297" name="WIFI_NETWORK_DELETE">
+      <description>Delete wifi network from device</description>
+      <field type="char[32]" name="ssid">Name of Wi-Fi network</field>
     </message>
     <message id="298" name="WIFI_NETWORKS_COUNT">
       <description>Number of saved/scanned Wi-Fi networks (See MAV_CMD_GET_WIFI_NETWORKS_COUNT)</description>


### PR DESCRIPTION
In this PR I propose to add new messages for setup Wi-Fi of the vehicle using GCS.

Description:
Vehicle can be in 2 states: connected to selected network (Client mode) or create it's own AP (Access Point). Vehicle will have a list of saved (by user) networks to which it may try to connect. If vehicle can't connect to any network then it will start in AP mode.

Communication with GCS (Initially vehicle in AP):
- GCS requests wifi status (MAV_CMD_GET_WIFI_STATUS) ()
- GCS requests for number of saved networks (MAV_CMD_GET_WIFI_NETWORKS_COUNT, WIFI_NETWORKS_COUNT)
- GCS requests for networks info (MAV_CMD_GET_WIFI_NETWORKS_INFO, WIFI_NETWORS_INFO)
- User connects Vehicle to selected network (WIFI_NETWORK_CONNECT)
- Vehicle switches to Client Mode
- After that user can connect to Vehicle again through WiFi 

Additionally, GCS can:
- Start vehicle in AP mode using MAV_CMD_WIFI_START_AP command.
- Add new network (SSID, protocol, password) to saved networks using WIFI_NETWORK_ADD message.
- Delete selected network from saved networks using WIFI_NETWORK_DELETE message.

Also GCS can use messages MAV_CMD_GET_WIFI_NETWORKS_INFO, WIFI_NETWORKS_INFO, MAV_CMD_GET_WIFI_NETWORKS_COUNT, WIFI_NETWORKS_COUNT for obtaining list of scanned networks (Networks which available for connection)